### PR TITLE
修正當段落少於兩行時，縮排出現錯誤的問題

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -9,6 +9,10 @@ body {
   margin-bottom: 20px;
 }
 
+.theme-showcase > p {
+  min-height: 70px;
+}
+
 .theme-showcase > p > .btn {
   margin: 5px 0;
 }


### PR DESCRIPTION
![osx 2017-09-14 11 49 10](https://user-images.githubusercontent.com/7029623/30439972-da52af62-99a7-11e7-9b16-df0690b43d77.png)

HTTPS Everywhere 這個段落有縮排的問題，主要似乎是因為 Header 沒有加上 `<h3>` 標籤；不過從原始碼看起來已經加上去了，但好像還沒推上線。而加上 `<h3>` 標籤之後還有第二個問題，就是若上一段的段落文字過少，導致容器高度低於左方圖片 `70px` 時，似乎還是會有縮排的問題。

因此在這個段落的 `<p>` 標籤上都加上了最小高度的下限 `70px` 來撐出基本的容器高度。